### PR TITLE
Fix potential crash on `didEndDisplayingCell`

### DIFF
--- a/FeedFetchApp/FeedFetchApp.xcodeproj/project.pbxproj
+++ b/FeedFetchApp/FeedFetchApp.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		5BB7914924D08DEB008C7CE3 /* FeedAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB7914824D08DEA008C7CE3 /* FeedAcceptanceTests.swift */; };
 		5BB7914B24D0D8FA008C7CE3 /* HTTPClientStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB7914A24D0D8F9008C7CE3 /* HTTPClientStub.swift */; };
 		5BB7914D24D0D94F008C7CE3 /* InMemoryFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB7914C24D0D94F008C7CE3 /* InMemoryFeedStore.swift */; };
+		5BB7915824D2074B008C7CE3 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB7915724D2074A008C7CE3 /* UIView+TestHelpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,6 +123,7 @@
 		5BB7914824D08DEA008C7CE3 /* FeedAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAcceptanceTests.swift; sourceTree = "<group>"; };
 		5BB7914A24D0D8F9008C7CE3 /* HTTPClientStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientStub.swift; sourceTree = "<group>"; };
 		5BB7914C24D0D94F008C7CE3 /* InMemoryFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryFeedStore.swift; sourceTree = "<group>"; };
+		5BB7915724D2074A008C7CE3 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,6 +233,7 @@
 				5BB790FD24CB684F008C7CE3 /* FeedImageDataLoaderSpy.swift */,
 				5BB7914A24D0D8F9008C7CE3 /* HTTPClientStub.swift */,
 				5BB7914C24D0D94F008C7CE3 /* InMemoryFeedStore.swift */,
+				5BB7915724D2074A008C7CE3 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				5B6714D524CA46BA00FB37AB /* XCTestCase+TrackMemoryLeaks.swift in Sources */,
 				5BB7913D24D08687008C7CE3 /* FeedUIIntegrationTests+LoaderSpy.swift in Sources */,
 				5BB7910024CB68F4008C7CE3 /* XCTestCase+ FeedImageDataLoader.swift in Sources */,
+				5BB7915824D2074B008C7CE3 /* UIView+TestHelpers.swift in Sources */,
 				5B6714D824CA47B300FB37AB /* FeedFetchAppTestsHelpers.swift in Sources */,
 				5BB7913924D08687008C7CE3 /* UIButton+TestHelpers.swift in Sources */,
 				5B6714DE24CB4F8400FB37AB /* FeedLoaderStub.swift in Sources */,

--- a/FeedFetchApp/FeedFetchAppTests/FeedUIIntegrationTests.swift
+++ b/FeedFetchApp/FeedFetchAppTests/FeedUIIntegrationTests.swift
@@ -68,6 +68,20 @@ class FeedUIIntegrationTests: XCTestCase {
         assert(sut, isRendering: multipleImages)
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNotEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeLoad(with: [image0, image1], at: 0)
+        assert(sut, isRendering: [image0, image1])
+                                
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeLoad(with: [], at: 1)
+        assert(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage(description: "a description", location: "a location")
         let (sut, loader) = makeSUT()

--- a/FeedFetchApp/FeedFetchAppTests/Helpers/FeedUIIntegrationTests+Asserts.swift
+++ b/FeedFetchApp/FeedFetchAppTests/Helpers/FeedUIIntegrationTests+Asserts.swift
@@ -8,8 +8,7 @@ import FeedFetcher
 
 extension FeedUIIntegrationTests {
     func assert(_ sut: FeedViewController, isRendering feed:[FeedImage], file: StaticString = #file, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        sut.view.enforceLayoutCycle()
         
         XCTAssertEqual(sut.numberOfRenderedFeedImagesView(), feed.count, "Expected to render a total of \(feed.count) image views", file: file, line: line)
         

--- a/FeedFetchApp/FeedFetchAppTests/Helpers/FeedUIIntegrationTests+Asserts.swift
+++ b/FeedFetchApp/FeedFetchAppTests/Helpers/FeedUIIntegrationTests+Asserts.swift
@@ -8,6 +8,9 @@ import FeedFetcher
 
 extension FeedUIIntegrationTests {
     func assert(_ sut: FeedViewController, isRendering feed:[FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         XCTAssertEqual(sut.numberOfRenderedFeedImagesView(), feed.count, "Expected to render a total of \(feed.count) image views", file: file, line: line)
         
         feed.enumerated().forEach{ index, image in

--- a/FeedFetchApp/FeedFetchAppTests/Helpers/UIView+TestHelpers.swift
+++ b/FeedFetchApp/FeedFetchAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,11 @@
+//  Created by Ivan Fuertes on 29/07/20.
+//  Copyright © 2020 Ivan Fuertes. All rights reserved.
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/FeedFetcher/FeedFetcheriOS/Feed UI/Controllers/FeedViewController.swift
+++ b/FeedFetcher/FeedFetcheriOS/Feed UI/Controllers/FeedViewController.swift
@@ -10,7 +10,8 @@ public protocol FeedViewControllerDelegate {
 
 final public class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
     @IBOutlet public private(set) var errorView: ErrorView!
-            
+
+    private var loadingControllers = [IndexPath : FeedImageCellController]()
     private var tableModel = [FeedImageCellController]() {
         didSet { self.tableView.reloadData() }
     }
@@ -28,6 +29,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -73,10 +75,14 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls didEndDisplayingCell for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.